### PR TITLE
fix(services-view): opening bottom sheet moves fetch services button up

### DIFF
--- a/src/components/services-view.tsx
+++ b/src/components/services-view.tsx
@@ -104,13 +104,13 @@ export default function ServicesView() {
         >
           Fetch services
         </Button>
-        {selectedServiceId && (
-          <ServiceBottomSheet
-            hide={() => setSelectedServiceId(null)}
-            serviceId={selectedServiceId}
-          />
-        )}
       </SafeAreaView>
+      {selectedServiceId && (
+        <ServiceBottomSheet
+          hide={() => setSelectedServiceId(null)}
+          serviceId={selectedServiceId}
+        />
+      )}
     </ThemedView>
   )
 }


### PR DESCRIPTION
Fixes a bug, where opening a service's bottom sheet, the fetch services button would move up slightly.